### PR TITLE
Uprade Lief to the new unreleased version 0.12.0

### DIFF
--- a/derivation.nix
+++ b/derivation.nix
@@ -1,5 +1,11 @@
-{ stdenv, lib, poetry2nix, python39, poetryOverrides, writeScriptBin
-, makeWrapper }:
+{ stdenv
+, lib
+, poetry2nix
+, python39
+, poetryOverrides
+, writeScriptBin
+, makeWrapper
+}:
 poetry2nix.mkPoetryApplication {
   projectDir = ./.;
   python = python39;

--- a/derivation.nix
+++ b/derivation.nix
@@ -1,11 +1,5 @@
-{ stdenv
-, lib
-, poetry2nix
-, python39
-, poetryOverrides
-, writeScriptBin
-, makeWrapper
-}:
+{ stdenv, lib, poetry2nix, python39, poetryOverrides, writeScriptBin
+, makeWrapper }:
 poetry2nix.mkPoetryApplication {
   projectDir = ./.;
   python = python39;

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,10 +1,24 @@
 self: super: {
+
   # https://github.com/nix-community/poetry2nix/issues/218
   poetryOverrides = self: super: {
     typing-extensions = super.typing-extensions.overridePythonAttrs
       (old: { buildInputs = (old.buildInputs or [ ]) ++ [ self.flit-core ]; });
 
-    lief = super.lief.overridePythonAttrs (old: { dontUseCmakeConfigure = true; nativeBuildInputs = [ self.pkgs.cmake ]; });
+    # This is an unreleased version of Lief that fixes a bug when generates GNU notes
+    # https://github.com/lief-project/LIEF/commit/72ebe0d89e94c18d2b64da2cbbc7a0a0d53a5693
+    lief = super.lief.overridePythonAttrs (old: {
+      version = "0.12.72ebe0d";
+      src = super.pkgs.fetchFromGitHub {
+        owner = "lief-project";
+        repo = "LIEF";
+        rev = "72ebe0d89e94c18d2b64da2cbbc7a0a0d53a5693";
+        sha256 = "039fwn6b92aq2vb8s44ld5bclz4gz2f9ki2kj7gy31x9lzjldnwk";
+      };
+      enableParallelBuilding = true;
+      dontUseCmakeConfigure = true;
+      nativeBuildInputs = [ self.pkgs.cmake ];
+    });
   };
 
   shrinkwrap = self.callPackage ./derivation.nix { };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = "MIT"
 python = "^3.9"
 sh = "^1.14.2"
 click = "^8.0.3"
-lief = "^0.11.5"
+lief = "0.12.0"
 
 [tool.poetry.dev-dependencies]
 black = "^21.12b0"

--- a/scripts/upload-to-cache
+++ b/scripts/upload-to-cache
@@ -3,5 +3,5 @@
 nix-store -qR \
     --include-outputs \
     $(nix-store -qd $(nix build --json | jq -r '.[].outputs | to_entries[].value')) \
-    | grep '\.drv$' \
+    | grep -v '\.drv$' \
     | cachix push fzakaria


### PR DESCRIPTION
Lief had a bug where some binaries produced when mucking around with various things would _SIGSEGV_.
The author of Lief reworked how the "builder" operated in Lief and from what I can tell it has resolved the issue.